### PR TITLE
Feature/making editable views

### DIFF
--- a/JustThree.xcodeproj/project.pbxproj
+++ b/JustThree.xcodeproj/project.pbxproj
@@ -18,6 +18,8 @@
 		BD0CADA628E23DF7007D2EF7 /* UIView+PinnedSubview.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD0CADA528E23DF7007D2EF7 /* UIView+PinnedSubview.swift */; };
 		BD0CADAA28E23FE1007D2EF7 /* TextFieldContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD0CADA928E23FE1007D2EF7 /* TextFieldContentView.swift */; };
 		BD0CADAC28E240A2007D2EF7 /* UIContentConfiguration+Stateless.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD0CADAB28E240A2007D2EF7 /* UIContentConfiguration+Stateless.swift */; };
+		BD0CADAE28E380AC007D2EF7 /* TextViewContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD0CADAD28E380AC007D2EF7 /* TextViewContentView.swift */; };
+		BD0CADB028E38591007D2EF7 /* DatePickerContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD0CADAF28E38591007D2EF7 /* DatePickerContentView.swift */; };
 		BD559CB628DF624500625B82 /* Date+TextFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD559CB528DF624500625B82 /* Date+TextFormat.swift */; };
 		BD9EC94E28DE478300B803D7 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD9EC94D28DE478300B803D7 /* AppDelegate.swift */; };
 		BD9EC95028DE478300B803D7 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD9EC94F28DE478300B803D7 /* SceneDelegate.swift */; };
@@ -41,6 +43,8 @@
 		BD0CADA528E23DF7007D2EF7 /* UIView+PinnedSubview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+PinnedSubview.swift"; sourceTree = "<group>"; };
 		BD0CADA928E23FE1007D2EF7 /* TextFieldContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFieldContentView.swift; sourceTree = "<group>"; };
 		BD0CADAB28E240A2007D2EF7 /* UIContentConfiguration+Stateless.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIContentConfiguration+Stateless.swift"; sourceTree = "<group>"; };
+		BD0CADAD28E380AC007D2EF7 /* TextViewContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextViewContentView.swift; sourceTree = "<group>"; };
+		BD0CADAF28E38591007D2EF7 /* DatePickerContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatePickerContentView.swift; sourceTree = "<group>"; };
 		BD559CB528DF624500625B82 /* Date+TextFormat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+TextFormat.swift"; sourceTree = "<group>"; };
 		BD9EC94A28DE478300B803D7 /* JustThree.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = JustThree.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BD9EC94D28DE478300B803D7 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -103,8 +107,10 @@
 			isa = PBXGroup;
 			children = (
 				BD0CADA528E23DF7007D2EF7 /* UIView+PinnedSubview.swift */,
-				BD0CADA928E23FE1007D2EF7 /* TextFieldContentView.swift */,
 				BD0CADAB28E240A2007D2EF7 /* UIContentConfiguration+Stateless.swift */,
+				BD0CADA928E23FE1007D2EF7 /* TextFieldContentView.swift */,
+				BD0CADAD28E380AC007D2EF7 /* TextViewContentView.swift */,
+				BD0CADAF28E38591007D2EF7 /* DatePickerContentView.swift */,
 			);
 			path = ContentViews;
 			sourceTree = "<group>";
@@ -230,12 +236,14 @@
 				BD0CADA328E23BD7007D2EF7 /* ReminderViewController+CellConfiguration.swift in Sources */,
 				BD9EC96328DE553B00B803D7 /* ReminderListViewController.swift in Sources */,
 				BD9EC95228DE478300B803D7 /* MainTabBarViewController.swift in Sources */,
+				BD0CADAE28E380AC007D2EF7 /* TextViewContentView.swift in Sources */,
 				BD9EC96828DF520400B803D7 /* Reminder.swift in Sources */,
 				BD0CAD9728E1DA65007D2EF7 /* ReminderDoneButton.swift in Sources */,
 				BD0CADAA28E23FE1007D2EF7 /* TextFieldContentView.swift in Sources */,
 				BD0CAD9D28E1E2A2007D2EF7 /* ReminderViewController.swift in Sources */,
 				BD0CAD9F28E1E3C6007D2EF7 /* ReminderViewController+Row.swift in Sources */,
 				BD0CADA628E23DF7007D2EF7 /* UIView+PinnedSubview.swift in Sources */,
+				BD0CADB028E38591007D2EF7 /* DatePickerContentView.swift in Sources */,
 				BD0CAD9928E1DAC7007D2EF7 /* ReminderListViewController+Actions.swift in Sources */,
 				BD9EC94E28DE478300B803D7 /* AppDelegate.swift in Sources */,
 				BD9EC95028DE478300B803D7 /* SceneDelegate.swift in Sources */,

--- a/JustThree.xcodeproj/project.pbxproj
+++ b/JustThree.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		BD0CAD9F28E1E3C6007D2EF7 /* ReminderViewController+Row.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD0CAD9E28E1E3C6007D2EF7 /* ReminderViewController+Row.swift */; };
 		BD0CADA128E231D6007D2EF7 /* ReminderViewController+Section.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD0CADA028E231D6007D2EF7 /* ReminderViewController+Section.swift */; };
 		BD0CADA328E23BD7007D2EF7 /* ReminderViewController+CellConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD0CADA228E23BD7007D2EF7 /* ReminderViewController+CellConfiguration.swift */; };
+		BD0CADA628E23DF7007D2EF7 /* UIView+PinnedSubview.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD0CADA528E23DF7007D2EF7 /* UIView+PinnedSubview.swift */; };
 		BD559CB628DF624500625B82 /* Date+TextFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD559CB528DF624500625B82 /* Date+TextFormat.swift */; };
 		BD9EC94E28DE478300B803D7 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD9EC94D28DE478300B803D7 /* AppDelegate.swift */; };
 		BD9EC95028DE478300B803D7 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD9EC94F28DE478300B803D7 /* SceneDelegate.swift */; };
@@ -35,6 +36,7 @@
 		BD0CAD9E28E1E3C6007D2EF7 /* ReminderViewController+Row.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReminderViewController+Row.swift"; sourceTree = "<group>"; };
 		BD0CADA028E231D6007D2EF7 /* ReminderViewController+Section.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReminderViewController+Section.swift"; sourceTree = "<group>"; };
 		BD0CADA228E23BD7007D2EF7 /* ReminderViewController+CellConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReminderViewController+CellConfiguration.swift"; sourceTree = "<group>"; };
+		BD0CADA528E23DF7007D2EF7 /* UIView+PinnedSubview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+PinnedSubview.swift"; sourceTree = "<group>"; };
 		BD559CB528DF624500625B82 /* Date+TextFormat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+TextFormat.swift"; sourceTree = "<group>"; };
 		BD9EC94A28DE478300B803D7 /* JustThree.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = JustThree.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BD9EC94D28DE478300B803D7 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -93,6 +95,14 @@
 			path = ReminderViewController;
 			sourceTree = "<group>";
 		};
+		BD0CADA428E23DCD007D2EF7 /* ContentViews */ = {
+			isa = PBXGroup;
+			children = (
+				BD0CADA528E23DF7007D2EF7 /* UIView+PinnedSubview.swift */,
+			);
+			path = ContentViews;
+			sourceTree = "<group>";
+		};
 		BD9EC94128DE478300B803D7 = {
 			isa = PBXGroup;
 			children = (
@@ -113,8 +123,9 @@
 		BD9EC94C28DE478300B803D7 /* JustThree */ = {
 			isa = PBXGroup;
 			children = (
-				BD0CAD9028E1CF2E007D2EF7 /* ViewController */,
 				BD9EC96628DF51EF00B803D7 /* Models */,
+				BD0CADA428E23DCD007D2EF7 /* ContentViews */,
+				BD0CAD9028E1CF2E007D2EF7 /* ViewController */,
 				BD9EC94D28DE478300B803D7 /* AppDelegate.swift */,
 				BD9EC94F28DE478300B803D7 /* SceneDelegate.swift */,
 				BD9EC95628DE478400B803D7 /* Assets.xcassets */,
@@ -216,6 +227,7 @@
 				BD0CAD9728E1DA65007D2EF7 /* ReminderDoneButton.swift in Sources */,
 				BD0CAD9D28E1E2A2007D2EF7 /* ReminderViewController.swift in Sources */,
 				BD0CAD9F28E1E3C6007D2EF7 /* ReminderViewController+Row.swift in Sources */,
+				BD0CADA628E23DF7007D2EF7 /* UIView+PinnedSubview.swift in Sources */,
 				BD0CAD9928E1DAC7007D2EF7 /* ReminderListViewController+Actions.swift in Sources */,
 				BD9EC94E28DE478300B803D7 /* AppDelegate.swift in Sources */,
 				BD9EC95028DE478300B803D7 /* SceneDelegate.swift in Sources */,

--- a/JustThree.xcodeproj/project.pbxproj
+++ b/JustThree.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		BD0CAD9928E1DAC7007D2EF7 /* ReminderListViewController+Actions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD0CAD9828E1DAC7007D2EF7 /* ReminderListViewController+Actions.swift */; };
 		BD0CAD9D28E1E2A2007D2EF7 /* ReminderViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD0CAD9C28E1E2A2007D2EF7 /* ReminderViewController.swift */; };
 		BD0CAD9F28E1E3C6007D2EF7 /* ReminderViewController+Row.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD0CAD9E28E1E3C6007D2EF7 /* ReminderViewController+Row.swift */; };
+		BD0CADA128E231D6007D2EF7 /* ReminderViewController+Section.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD0CADA028E231D6007D2EF7 /* ReminderViewController+Section.swift */; };
 		BD559CB628DF624500625B82 /* Date+TextFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD559CB528DF624500625B82 /* Date+TextFormat.swift */; };
 		BD9EC94E28DE478300B803D7 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD9EC94D28DE478300B803D7 /* AppDelegate.swift */; };
 		BD9EC95028DE478300B803D7 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD9EC94F28DE478300B803D7 /* SceneDelegate.swift */; };
@@ -31,6 +32,7 @@
 		BD0CAD9828E1DAC7007D2EF7 /* ReminderListViewController+Actions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReminderListViewController+Actions.swift"; sourceTree = "<group>"; };
 		BD0CAD9C28E1E2A2007D2EF7 /* ReminderViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReminderViewController.swift; sourceTree = "<group>"; };
 		BD0CAD9E28E1E3C6007D2EF7 /* ReminderViewController+Row.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReminderViewController+Row.swift"; sourceTree = "<group>"; };
+		BD0CADA028E231D6007D2EF7 /* ReminderViewController+Section.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReminderViewController+Section.swift"; sourceTree = "<group>"; };
 		BD559CB528DF624500625B82 /* Date+TextFormat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+TextFormat.swift"; sourceTree = "<group>"; };
 		BD9EC94A28DE478300B803D7 /* JustThree.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = JustThree.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BD9EC94D28DE478300B803D7 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -83,6 +85,7 @@
 			children = (
 				BD0CAD9C28E1E2A2007D2EF7 /* ReminderViewController.swift */,
 				BD0CAD9E28E1E3C6007D2EF7 /* ReminderViewController+Row.swift */,
+				BD0CADA028E231D6007D2EF7 /* ReminderViewController+Section.swift */,
 			);
 			path = ReminderViewController;
 			sourceTree = "<group>";
@@ -198,6 +201,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BD0CADA128E231D6007D2EF7 /* ReminderViewController+Section.swift in Sources */,
 				BD0CAD9228E1CF81007D2EF7 /* UIColor+JustThree.swift in Sources */,
 				BD559CB628DF624500625B82 /* Date+TextFormat.swift in Sources */,
 				BD0CAD9428E1D0FC007D2EF7 /* ReminderListViewController+DataSource.swift in Sources */,

--- a/JustThree.xcodeproj/project.pbxproj
+++ b/JustThree.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		BD0CAD9D28E1E2A2007D2EF7 /* ReminderViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD0CAD9C28E1E2A2007D2EF7 /* ReminderViewController.swift */; };
 		BD0CAD9F28E1E3C6007D2EF7 /* ReminderViewController+Row.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD0CAD9E28E1E3C6007D2EF7 /* ReminderViewController+Row.swift */; };
 		BD0CADA128E231D6007D2EF7 /* ReminderViewController+Section.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD0CADA028E231D6007D2EF7 /* ReminderViewController+Section.swift */; };
+		BD0CADA328E23BD7007D2EF7 /* ReminderViewController+CellConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD0CADA228E23BD7007D2EF7 /* ReminderViewController+CellConfiguration.swift */; };
 		BD559CB628DF624500625B82 /* Date+TextFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD559CB528DF624500625B82 /* Date+TextFormat.swift */; };
 		BD9EC94E28DE478300B803D7 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD9EC94D28DE478300B803D7 /* AppDelegate.swift */; };
 		BD9EC95028DE478300B803D7 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD9EC94F28DE478300B803D7 /* SceneDelegate.swift */; };
@@ -33,6 +34,7 @@
 		BD0CAD9C28E1E2A2007D2EF7 /* ReminderViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReminderViewController.swift; sourceTree = "<group>"; };
 		BD0CAD9E28E1E3C6007D2EF7 /* ReminderViewController+Row.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReminderViewController+Row.swift"; sourceTree = "<group>"; };
 		BD0CADA028E231D6007D2EF7 /* ReminderViewController+Section.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReminderViewController+Section.swift"; sourceTree = "<group>"; };
+		BD0CADA228E23BD7007D2EF7 /* ReminderViewController+CellConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReminderViewController+CellConfiguration.swift"; sourceTree = "<group>"; };
 		BD559CB528DF624500625B82 /* Date+TextFormat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+TextFormat.swift"; sourceTree = "<group>"; };
 		BD9EC94A28DE478300B803D7 /* JustThree.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = JustThree.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BD9EC94D28DE478300B803D7 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -86,6 +88,7 @@
 				BD0CAD9C28E1E2A2007D2EF7 /* ReminderViewController.swift */,
 				BD0CAD9E28E1E3C6007D2EF7 /* ReminderViewController+Row.swift */,
 				BD0CADA028E231D6007D2EF7 /* ReminderViewController+Section.swift */,
+				BD0CADA228E23BD7007D2EF7 /* ReminderViewController+CellConfiguration.swift */,
 			);
 			path = ReminderViewController;
 			sourceTree = "<group>";
@@ -206,6 +209,7 @@
 				BD559CB628DF624500625B82 /* Date+TextFormat.swift in Sources */,
 				BD0CAD9428E1D0FC007D2EF7 /* ReminderListViewController+DataSource.swift in Sources */,
 				BD9EC96528DE55AD00B803D7 /* SettingListViewController.swift in Sources */,
+				BD0CADA328E23BD7007D2EF7 /* ReminderViewController+CellConfiguration.swift in Sources */,
 				BD9EC96328DE553B00B803D7 /* ReminderListViewController.swift in Sources */,
 				BD9EC95228DE478300B803D7 /* MainTabBarViewController.swift in Sources */,
 				BD9EC96828DF520400B803D7 /* Reminder.swift in Sources */,

--- a/JustThree.xcodeproj/project.pbxproj
+++ b/JustThree.xcodeproj/project.pbxproj
@@ -16,6 +16,8 @@
 		BD0CADA128E231D6007D2EF7 /* ReminderViewController+Section.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD0CADA028E231D6007D2EF7 /* ReminderViewController+Section.swift */; };
 		BD0CADA328E23BD7007D2EF7 /* ReminderViewController+CellConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD0CADA228E23BD7007D2EF7 /* ReminderViewController+CellConfiguration.swift */; };
 		BD0CADA628E23DF7007D2EF7 /* UIView+PinnedSubview.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD0CADA528E23DF7007D2EF7 /* UIView+PinnedSubview.swift */; };
+		BD0CADAA28E23FE1007D2EF7 /* TextFieldContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD0CADA928E23FE1007D2EF7 /* TextFieldContentView.swift */; };
+		BD0CADAC28E240A2007D2EF7 /* UIContentConfiguration+Stateless.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD0CADAB28E240A2007D2EF7 /* UIContentConfiguration+Stateless.swift */; };
 		BD559CB628DF624500625B82 /* Date+TextFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD559CB528DF624500625B82 /* Date+TextFormat.swift */; };
 		BD9EC94E28DE478300B803D7 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD9EC94D28DE478300B803D7 /* AppDelegate.swift */; };
 		BD9EC95028DE478300B803D7 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD9EC94F28DE478300B803D7 /* SceneDelegate.swift */; };
@@ -37,6 +39,8 @@
 		BD0CADA028E231D6007D2EF7 /* ReminderViewController+Section.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReminderViewController+Section.swift"; sourceTree = "<group>"; };
 		BD0CADA228E23BD7007D2EF7 /* ReminderViewController+CellConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReminderViewController+CellConfiguration.swift"; sourceTree = "<group>"; };
 		BD0CADA528E23DF7007D2EF7 /* UIView+PinnedSubview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+PinnedSubview.swift"; sourceTree = "<group>"; };
+		BD0CADA928E23FE1007D2EF7 /* TextFieldContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFieldContentView.swift; sourceTree = "<group>"; };
+		BD0CADAB28E240A2007D2EF7 /* UIContentConfiguration+Stateless.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIContentConfiguration+Stateless.swift"; sourceTree = "<group>"; };
 		BD559CB528DF624500625B82 /* Date+TextFormat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+TextFormat.swift"; sourceTree = "<group>"; };
 		BD9EC94A28DE478300B803D7 /* JustThree.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = JustThree.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BD9EC94D28DE478300B803D7 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -99,6 +103,8 @@
 			isa = PBXGroup;
 			children = (
 				BD0CADA528E23DF7007D2EF7 /* UIView+PinnedSubview.swift */,
+				BD0CADA928E23FE1007D2EF7 /* TextFieldContentView.swift */,
+				BD0CADAB28E240A2007D2EF7 /* UIContentConfiguration+Stateless.swift */,
 			);
 			path = ContentViews;
 			sourceTree = "<group>";
@@ -220,11 +226,13 @@
 				BD559CB628DF624500625B82 /* Date+TextFormat.swift in Sources */,
 				BD0CAD9428E1D0FC007D2EF7 /* ReminderListViewController+DataSource.swift in Sources */,
 				BD9EC96528DE55AD00B803D7 /* SettingListViewController.swift in Sources */,
+				BD0CADAC28E240A2007D2EF7 /* UIContentConfiguration+Stateless.swift in Sources */,
 				BD0CADA328E23BD7007D2EF7 /* ReminderViewController+CellConfiguration.swift in Sources */,
 				BD9EC96328DE553B00B803D7 /* ReminderListViewController.swift in Sources */,
 				BD9EC95228DE478300B803D7 /* MainTabBarViewController.swift in Sources */,
 				BD9EC96828DF520400B803D7 /* Reminder.swift in Sources */,
 				BD0CAD9728E1DA65007D2EF7 /* ReminderDoneButton.swift in Sources */,
+				BD0CADAA28E23FE1007D2EF7 /* TextFieldContentView.swift in Sources */,
 				BD0CAD9D28E1E2A2007D2EF7 /* ReminderViewController.swift in Sources */,
 				BD0CAD9F28E1E3C6007D2EF7 /* ReminderViewController+Row.swift in Sources */,
 				BD0CADA628E23DF7007D2EF7 /* UIView+PinnedSubview.swift in Sources */,

--- a/JustThree/ContentViews/DatePickerContentView.swift
+++ b/JustThree/ContentViews/DatePickerContentView.swift
@@ -1,0 +1,48 @@
+//
+//  DatePickerContentView.swift
+//  JustThree
+//
+//  Created by Sanghun Park on 27.09.22.
+//
+
+import UIKit
+
+class DatePickerContentView: UIView, UIContentView {
+    struct Configuration: UIContentConfiguration {
+        var date = Date.now
+        
+        func makeContentView() -> UIView & UIContentView {
+            return DatePickerContentView(self)
+        }
+    }
+    
+    let datePicker = UIDatePicker()
+    var configuration: UIContentConfiguration {
+        didSet {
+            configure(configuration: configuration)
+        }
+    }
+    
+    init(_ configuration: UIContentConfiguration) {
+        self.configuration = configuration
+        super.init(frame: .zero)
+        addPinnedSubview(datePicker)
+        datePicker.preferredDatePickerStyle = .inline
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    func configure(configuration: UIContentConfiguration) {
+        guard let configuration = configuration as? Configuration else { return }
+        datePicker.date = configuration.date
+    }
+}
+
+extension UICollectionViewListCell {
+    func datePickerConfiguration() -> DatePickerContentView.Configuration {
+        DatePickerContentView.Configuration()
+    }
+}
+

--- a/JustThree/ContentViews/TextFieldContentView.swift
+++ b/JustThree/ContentViews/TextFieldContentView.swift
@@ -1,0 +1,51 @@
+//
+//  TextFieldContentView.swift
+//  JustThree
+//
+//  Created by Sanghun Park on 26.09.22.
+//
+
+import UIKit
+
+class TextFieldContentView: UIView, UIContentView {
+    struct Configuration: UIContentConfiguration {
+        var text: String? = ""
+        
+        func makeContentView() -> UIView & UIContentView {
+            return TextFieldContentView(self)
+        }
+    }
+    
+    let textField = UITextField()
+    var configuration: UIContentConfiguration {
+        didSet {
+            configure(configuration: configuration)
+        }
+    }
+    
+    override var intrinsicContentSize: CGSize {
+        CGSize(width: 0, height: 44)
+    }
+    
+    init(_ configuration: UIContentConfiguration) {
+        self.configuration = configuration
+        super.init(frame: .zero)
+        addPinnedSubview(textField, insets: UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 16))
+        textField.clearButtonMode = .whileEditing
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    func configure(configuration: UIContentConfiguration) {
+        guard let configuration = configuration as? Configuration else { return }
+        textField.text = configuration.text
+    }
+}
+
+extension UICollectionViewListCell {
+    func textFieldConfiguration() -> TextFieldContentView.Configuration {
+        TextFieldContentView.Configuration()
+    }
+}

--- a/JustThree/ContentViews/TextViewContentView.swift
+++ b/JustThree/ContentViews/TextViewContentView.swift
@@ -1,0 +1,52 @@
+//
+//  TextViewContentView.swift
+//  JustThree
+//
+//  Created by Sanghun Park on 27.09.22.
+//
+
+import UIKit
+
+class TextViewContentView: UIView, UIContentView {
+    struct Configuration: UIContentConfiguration {
+        var text: String? = ""
+        
+        func makeContentView() -> UIView & UIContentView {
+            return TextViewContentView(self)
+        }
+    }
+    
+    let textView = UITextView()
+    var configuration: UIContentConfiguration {
+        didSet {
+            configure(configuration: configuration)
+        }
+    }
+    
+    override var intrinsicContentSize: CGSize {
+        CGSize(width: 0, height: 44)
+    }
+    
+    init(_ configuration: UIContentConfiguration) {
+        self.configuration = configuration
+        super.init(frame: .zero)
+        addPinnedSubview(textView, height: 200)
+        textView.backgroundColor = nil
+        textView.font = UIFont.preferredFont(forTextStyle: .body)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    func configure(configuration: UIContentConfiguration) {
+        guard let configuration = configuration as? Configuration else { return }
+        textView.text = configuration.text
+    }
+}
+
+extension UICollectionViewListCell {
+    func textViewConfiguration() -> TextViewContentView.Configuration {
+        TextViewContentView.Configuration()
+    }
+}

--- a/JustThree/ContentViews/UIContentConfiguration+Stateless.swift
+++ b/JustThree/ContentViews/UIContentConfiguration+Stateless.swift
@@ -1,0 +1,14 @@
+//
+//  UIContentConfiguration+Stateless.swift
+//  JustThree
+//
+//  Created by Sanghun Park on 26.09.22.
+//
+
+import UIKit
+
+extension UIContentConfiguration {
+    func updated(for state: UIConfigurationState) -> Self {
+        return self
+    }
+}

--- a/JustThree/ContentViews/UIView+PinnedSubview.swift
+++ b/JustThree/ContentViews/UIView+PinnedSubview.swift
@@ -1,0 +1,25 @@
+//
+//  UIView+PinnedSubview.swift
+//  JustThree
+//
+//  Created by Sanghun Park on 26.09.22.
+//
+
+import UIKit
+
+extension UIView {
+    func addPinnedSubview(_ subview: UIView, height: CGFloat? = nil, insets: UIEdgeInsets = UIEdgeInsets(top: 0, left: 8, bottom: 0, right: 8)) {
+        
+        addSubview(subview)
+        
+        subview.translatesAutoresizingMaskIntoConstraints = false
+        
+        subview.topAnchor.constraint(equalTo: topAnchor, constant: insets.top).isActive = true
+        subview.leadingAnchor.constraint(equalTo: leadingAnchor, constant: insets.left).isActive = true
+        subview.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -1.0 * insets.right).isActive = true
+        subview.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -1.0 * insets.bottom).isActive = true
+        if let height = height {
+            subview.heightAnchor.constraint(equalToConstant: height).isActive = true
+        }
+    }
+}

--- a/JustThree/ViewController/ReminderViewController/ReminderViewController+CellConfiguration.swift
+++ b/JustThree/ViewController/ReminderViewController/ReminderViewController+CellConfiguration.swift
@@ -23,6 +23,12 @@ extension ReminderViewController {
         return contentConfig
     }
     
+    func titleConfiguration(for cell: UICollectionViewListCell, with title: String?) -> TextFieldContentView.Configuration {
+        var contentConfig = cell.textFieldConfiguration()
+        contentConfig.text = title
+        return contentConfig
+    }
+    
     private func text(for row: Row) -> String? {
         switch row {
         case .viewDate: return reminder.dueDate.dayText

--- a/JustThree/ViewController/ReminderViewController/ReminderViewController+CellConfiguration.swift
+++ b/JustThree/ViewController/ReminderViewController/ReminderViewController+CellConfiguration.swift
@@ -1,0 +1,36 @@
+//
+//  ReminderViewController+CellConfiguration.swift
+//  JustThree
+//
+//  Created by Sanghun Park on 26.09.22.
+//
+
+import UIKit
+
+extension ReminderViewController {
+    
+    func defaultConfiguration(for cell: UICollectionViewListCell, at row: Row) -> UIListContentConfiguration {
+        var contentConfig = cell.defaultContentConfiguration()
+        contentConfig.text = self.text(for: row)
+        contentConfig.textProperties.font = UIFont.preferredFont(forTextStyle: row.textStyle)
+        contentConfig.image = row.image
+        return contentConfig
+    }
+    
+    func headerConfiguration(for cell: UICollectionViewListCell, with title: String) -> UIListContentConfiguration {
+        var contentConfig = cell.defaultContentConfiguration()
+        contentConfig.text = title
+        return contentConfig
+    }
+    
+    private func text(for row: Row) -> String? {
+        switch row {
+        case .viewDate: return reminder.dueDate.dayText
+        case .viewNotes: return reminder.notes
+        case .viewTime: return reminder.dueDate.formatted(date: .omitted, time: .shortened)
+        case .viewTitle: return reminder.title
+        default: return nil
+        }
+    }
+    
+}

--- a/JustThree/ViewController/ReminderViewController/ReminderViewController+CellConfiguration.swift
+++ b/JustThree/ViewController/ReminderViewController/ReminderViewController+CellConfiguration.swift
@@ -29,6 +29,18 @@ extension ReminderViewController {
         return contentConfig
     }
     
+    func dateConfiguration(for cell: UICollectionViewListCell, with date: Date) -> DatePickerContentView.Configuration {
+        var contentConfig = cell.datePickerConfiguration()
+        contentConfig.date = date
+        return contentConfig
+    }
+    
+    func notesConfiguration(for cell: UICollectionViewListCell, with notes: String?) -> TextViewContentView.Configuration {
+        var contentConfig = cell.textViewConfiguration()
+        contentConfig.text = notes
+        return contentConfig
+    }
+    
     private func text(for row: Row) -> String? {
         switch row {
         case .viewDate: return reminder.dueDate.dayText

--- a/JustThree/ViewController/ReminderViewController/ReminderViewController+Row.swift
+++ b/JustThree/ViewController/ReminderViewController/ReminderViewController+Row.swift
@@ -9,6 +9,7 @@ import UIKit
 
 extension ReminderViewController {
     enum Row: Hashable {
+        case header(String)
         case viewDate
         case viewNotes
         case viewTime

--- a/JustThree/ViewController/ReminderViewController/ReminderViewController+Row.swift
+++ b/JustThree/ViewController/ReminderViewController/ReminderViewController+Row.swift
@@ -14,6 +14,7 @@ extension ReminderViewController {
         case viewNotes
         case viewTime
         case viewTitle
+        case editText(String)
         
         var imageName: String? {
             switch self {

--- a/JustThree/ViewController/ReminderViewController/ReminderViewController+Row.swift
+++ b/JustThree/ViewController/ReminderViewController/ReminderViewController+Row.swift
@@ -14,7 +14,8 @@ extension ReminderViewController {
         case viewNotes
         case viewTime
         case viewTitle
-        case editText(String)
+        case editDate(Date)
+        case editText(String?)
         
         var imageName: String? {
             switch self {

--- a/JustThree/ViewController/ReminderViewController/ReminderViewController+Section.swift
+++ b/JustThree/ViewController/ReminderViewController/ReminderViewController+Section.swift
@@ -1,0 +1,29 @@
+//
+//  ReminderViewController+Section.swift
+//  JustThree
+//
+//  Created by Sanghun Park on 26.09.22.
+//
+
+import Foundation
+
+extension ReminderViewController {
+    enum Section: Int, Hashable {
+        case view
+        case notes
+        case date
+        case title
+        
+        var name: String {
+            switch self {
+            case .view: return ""
+            case .notes:
+                return NSLocalizedString("Notes", comment: "Notes section name")
+            case .date:
+                return NSLocalizedString("Date", comment: "Date section name")
+            case .title:
+                return NSLocalizedString("Title", comment: "Title section name")
+            }
+        }
+    }
+}

--- a/JustThree/ViewController/ReminderViewController/ReminderViewController+Section.swift
+++ b/JustThree/ViewController/ReminderViewController/ReminderViewController+Section.swift
@@ -10,9 +10,9 @@ import Foundation
 extension ReminderViewController {
     enum Section: Int, Hashable {
         case view
-        case notes
-        case date
         case title
+        case date
+        case notes
         
         var name: String {
             switch self {

--- a/JustThree/ViewController/ReminderViewController/ReminderViewController.swift
+++ b/JustThree/ViewController/ReminderViewController/ReminderViewController.swift
@@ -58,6 +58,8 @@ class ReminderViewController: UICollectionViewController {
                 cell.contentConfiguration = self.headerConfiguration(for: cell, with: title)
             case (.view, _):
                 cell.contentConfiguration = self.defaultConfiguration(for: cell, at: row)
+            case (.title, .editText(let title)):
+                cell.contentConfiguration = self.titleConfiguration(for: cell, with: title)
             default:
                 fatalError("Unexpected combination of section and row.")
             }
@@ -75,7 +77,7 @@ class ReminderViewController: UICollectionViewController {
     private func updateSnapshotForEditing() {
         var snapshot = Snapshot()
         snapshot.appendSections([.title, .date, .notes])
-        snapshot.appendItems([.header(Section.title.name)], toSection: .title)
+        snapshot.appendItems([.header(Section.title.name), .editText(reminder.title)], toSection: .title)
         snapshot.appendItems([.header(Section.date.name)], toSection: .date)
         snapshot.appendItems([.header(Section.notes.name)], toSection: .notes)
         dataSource.apply(snapshot)

--- a/JustThree/ViewController/ReminderViewController/ReminderViewController.swift
+++ b/JustThree/ViewController/ReminderViewController/ReminderViewController.swift
@@ -34,17 +34,23 @@ class ReminderViewController: UICollectionViewController {
         
         navigationItem.title = NSLocalizedString("Reminder", comment: "Reminder view controller title")
         
-        updateSnapshot()
+        updateSnapshotForViewing()
     }
     
     func cellRegistration() -> UICollectionView.CellRegistration<UICollectionViewListCell, Row> {
         return .init { (cell: UICollectionViewListCell, indexPath: IndexPath, row: Row) in
             
-            var contentConfig = cell.defaultContentConfiguration()
-            contentConfig.text = self.text(for: row)
-            contentConfig.textProperties.font = UIFont.preferredFont(forTextStyle: row.textStyle)
-            contentConfig.image = row.image
-            cell.contentConfiguration = contentConfig
+            let section = self.section(for: indexPath)
+            switch (section, row) {
+            case (.view, _):
+                var contentConfig = cell.defaultContentConfiguration()
+                contentConfig.text = self.text(for: row)
+                contentConfig.textProperties.font = UIFont.preferredFont(forTextStyle: row.textStyle)
+                contentConfig.image = row.image
+                cell.contentConfiguration = contentConfig
+            default:
+                fatalError("Unexpected combination of section and row.")
+            }
             cell.tintColor = .justThreePrimaryTint
         }
     }
@@ -56,7 +62,13 @@ class ReminderViewController: UICollectionViewController {
         }
     }
     
-    private func updateSnapshot() {
+    private func updateSnapshotForEditing() {
+        var snapshot = Snapshot()
+        snapshot.appendSections([.title, .date, .notes])
+        dataSource.apply(snapshot)
+    }
+    
+    private func updateSnapshotForViewing() {
         var snapshot = Snapshot()
         snapshot.appendSections([.view])
         snapshot.appendItems([.viewTitle, .viewDate, .viewTime, .viewNotes], toSection: .view)

--- a/JustThree/ViewController/ReminderViewController/ReminderViewController.swift
+++ b/JustThree/ViewController/ReminderViewController/ReminderViewController.swift
@@ -55,15 +55,9 @@ class ReminderViewController: UICollectionViewController {
             let section = self.section(for: indexPath)
             switch (section, row) {
             case (_, .header(let title)):
-                var contentConfig = cell.defaultContentConfiguration()
-                contentConfig.text = title
-                cell.contentConfiguration = contentConfig
+                cell.contentConfiguration = self.headerConfiguration(for: cell, with: title)
             case (.view, _):
-                var contentConfig = cell.defaultContentConfiguration()
-                contentConfig.text = self.text(for: row)
-                contentConfig.textProperties.font = UIFont.preferredFont(forTextStyle: row.textStyle)
-                contentConfig.image = row.image
-                cell.contentConfiguration = contentConfig
+                cell.contentConfiguration = self.defaultConfiguration(for: cell, at: row)
             default:
                 fatalError("Unexpected combination of section and row.")
             }
@@ -100,16 +94,6 @@ class ReminderViewController: UICollectionViewController {
             fatalError("Unable to find matching section")
         }
         return section
-    }
-    
-    func text(for row: Row) -> String? {
-        switch row {
-        case .viewDate: return reminder.dueDate.dayText
-        case .viewNotes: return reminder.notes
-        case .viewTime: return reminder.dueDate.formatted(date: .omitted, time: .shortened)
-        case .viewTitle: return reminder.title
-        default: return nil
-        }
     }
     
 }

--- a/JustThree/ViewController/ReminderViewController/ReminderViewController.swift
+++ b/JustThree/ViewController/ReminderViewController/ReminderViewController.swift
@@ -21,6 +21,7 @@ class ReminderViewController: UICollectionViewController {
         self.reminder = reminder
         var listConfiguration = UICollectionLayoutListConfiguration(appearance: .insetGrouped)
         listConfiguration.showsSeparators = false
+        listConfiguration.headerMode = .firstItemInSection
         let listLayout = UICollectionViewCompositionalLayout.list(using: listConfiguration)
         super.init(collectionViewLayout: listLayout)
     }
@@ -53,6 +54,10 @@ class ReminderViewController: UICollectionViewController {
             
             let section = self.section(for: indexPath)
             switch (section, row) {
+            case (_, .header(let title)):
+                var contentConfig = cell.defaultContentConfiguration()
+                contentConfig.text = title
+                cell.contentConfiguration = contentConfig
             case (.view, _):
                 var contentConfig = cell.defaultContentConfiguration()
                 contentConfig.text = self.text(for: row)
@@ -76,13 +81,16 @@ class ReminderViewController: UICollectionViewController {
     private func updateSnapshotForEditing() {
         var snapshot = Snapshot()
         snapshot.appendSections([.title, .date, .notes])
+        snapshot.appendItems([.header(Section.title.name)], toSection: .title)
+        snapshot.appendItems([.header(Section.date.name)], toSection: .date)
+        snapshot.appendItems([.header(Section.notes.name)], toSection: .notes)
         dataSource.apply(snapshot)
     }
     
     private func updateSnapshotForViewing() {
         var snapshot = Snapshot()
         snapshot.appendSections([.view])
-        snapshot.appendItems([.viewTitle, .viewDate, .viewTime, .viewNotes], toSection: .view)
+        snapshot.appendItems([.header(""), .viewTitle, .viewDate, .viewTime, .viewNotes], toSection: .view)
         dataSource.apply(snapshot)
     }
     
@@ -100,6 +108,7 @@ class ReminderViewController: UICollectionViewController {
         case .viewNotes: return reminder.notes
         case .viewTime: return reminder.dueDate.formatted(date: .omitted, time: .shortened)
         case .viewTitle: return reminder.title
+        default: return nil
         }
     }
     

--- a/JustThree/ViewController/ReminderViewController/ReminderViewController.swift
+++ b/JustThree/ViewController/ReminderViewController/ReminderViewController.swift
@@ -10,8 +10,8 @@ import UIKit
 //private let reuseIdentifier = "Cell"
 
 class ReminderViewController: UICollectionViewController {
-    private typealias DataSource = UICollectionViewDiffableDataSource<Int, Row>
-    private typealias Snapshot = NSDiffableDataSourceSnapshot<Int, Row>
+    private typealias DataSource = UICollectionViewDiffableDataSource<Section, Row>
+    private typealias Snapshot = NSDiffableDataSourceSnapshot<Section, Row>
 
     
     var reminder: Reminder
@@ -58,9 +58,17 @@ class ReminderViewController: UICollectionViewController {
     
     private func updateSnapshot() {
         var snapshot = Snapshot()
-        snapshot.appendSections([0])
-        snapshot.appendItems([.viewTitle, .viewDate, .viewTime, .viewNotes], toSection: 0)
+        snapshot.appendSections([.view])
+        snapshot.appendItems([.viewTitle, .viewDate, .viewTime, .viewNotes], toSection: .view)
         dataSource.apply(snapshot)
+    }
+    
+    private func section(for indexPath: IndexPath) -> Section {
+        let sectionNumber = isEditing ? indexPath.section + 1 : indexPath.section
+        guard let section = Section(rawValue: sectionNumber) else {
+            fatalError("Unable to find matching section")
+        }
+        return section
     }
     
     func text(for row: Row) -> String? {

--- a/JustThree/ViewController/ReminderViewController/ReminderViewController.swift
+++ b/JustThree/ViewController/ReminderViewController/ReminderViewController.swift
@@ -33,8 +33,19 @@ class ReminderViewController: UICollectionViewController {
         super.viewDidLoad()
         
         navigationItem.title = NSLocalizedString("Reminder", comment: "Reminder view controller title")
+        navigationItem.rightBarButtonItem = editButtonItem
         
         updateSnapshotForViewing()
+    }
+    
+    override func setEditing(_ editing: Bool, animated: Bool) {
+        super.setEditing(editing, animated: animated)
+        if editing {
+            updateSnapshotForEditing()
+        }
+        else {
+            updateSnapshotForViewing()
+        }
     }
     
     func cellRegistration() -> UICollectionView.CellRegistration<UICollectionViewListCell, Row> {

--- a/JustThree/ViewController/ReminderViewController/ReminderViewController.swift
+++ b/JustThree/ViewController/ReminderViewController/ReminderViewController.swift
@@ -60,6 +60,10 @@ class ReminderViewController: UICollectionViewController {
                 cell.contentConfiguration = self.defaultConfiguration(for: cell, at: row)
             case (.title, .editText(let title)):
                 cell.contentConfiguration = self.titleConfiguration(for: cell, with: title)
+            case (.date, .editDate(let date)):
+                cell.contentConfiguration = self.dateConfiguration(for: cell, with: date)
+            case (.notes, .editText(let notes)):
+                cell.contentConfiguration = self.notesConfiguration(for: cell, with: notes)
             default:
                 fatalError("Unexpected combination of section and row.")
             }
@@ -78,8 +82,8 @@ class ReminderViewController: UICollectionViewController {
         var snapshot = Snapshot()
         snapshot.appendSections([.title, .date, .notes])
         snapshot.appendItems([.header(Section.title.name), .editText(reminder.title)], toSection: .title)
-        snapshot.appendItems([.header(Section.date.name)], toSection: .date)
-        snapshot.appendItems([.header(Section.notes.name)], toSection: .notes)
+        snapshot.appendItems([.header(Section.date.name), .editDate(reminder.dueDate)], toSection: .date)
+        snapshot.appendItems([.header(Section.notes.name), .editText(reminder.notes)], toSection: .notes)
         dataSource.apply(snapshot)
     }
     


### PR DESCRIPTION
- Add capabilities to the app’s editing mode that transform a view-only list of reminder details into editable controls.
- Replace the content views of the detail view list cells with editable content views that are customized for the type of information in each cell.