### PR TITLE
Feature/editing reminders

### DIFF
--- a/JustThree/AppDelegate.swift
+++ b/JustThree/AppDelegate.swift
@@ -22,6 +22,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         navBarAppearance.configureWithOpaqueBackground()
         UINavigationBar.appearance().scrollEdgeAppearance = navBarAppearance
         
+        UITabBar.appearance().tintColor = .justThreePrimaryTint
+        UITabBar.appearance().backgroundColor = .justThreeNavigationBackground
+        
+        let tabBarAppearance = UITabBarAppearance()
+        tabBarAppearance.configureWithOpaqueBackground()
+        UITabBar.appearance().scrollEdgeAppearance = tabBarAppearance
+        
         return true
     }
 

--- a/JustThree/ContentViews/DatePickerContentView.swift
+++ b/JustThree/ContentViews/DatePickerContentView.swift
@@ -10,6 +10,7 @@ import UIKit
 class DatePickerContentView: UIView, UIContentView {
     struct Configuration: UIContentConfiguration {
         var date = Date.now
+        var onChange: (Date)->Void = { _ in }
         
         func makeContentView() -> UIView & UIContentView {
             return DatePickerContentView(self)
@@ -27,6 +28,7 @@ class DatePickerContentView: UIView, UIContentView {
         self.configuration = configuration
         super.init(frame: .zero)
         addPinnedSubview(datePicker)
+        datePicker.addTarget(self, action: #selector(didPick(_:)), for: .valueChanged)
         datePicker.preferredDatePickerStyle = .inline
     }
     
@@ -37,6 +39,11 @@ class DatePickerContentView: UIView, UIContentView {
     func configure(configuration: UIContentConfiguration) {
         guard let configuration = configuration as? Configuration else { return }
         datePicker.date = configuration.date
+    }
+    
+    @objc private func didPick(_ sender: UIDatePicker) {
+        guard let configuration = configuration as? DatePickerContentView.Configuration else { return }
+        configuration.onChange(sender.date)
     }
 }
 

--- a/JustThree/ContentViews/TextFieldContentView.swift
+++ b/JustThree/ContentViews/TextFieldContentView.swift
@@ -10,6 +10,7 @@ import UIKit
 class TextFieldContentView: UIView, UIContentView {
     struct Configuration: UIContentConfiguration {
         var text: String? = ""
+        var onChange: (String)->Void = { _ in }
         
         func makeContentView() -> UIView & UIContentView {
             return TextFieldContentView(self)
@@ -31,6 +32,7 @@ class TextFieldContentView: UIView, UIContentView {
         self.configuration = configuration
         super.init(frame: .zero)
         addPinnedSubview(textField, insets: UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 16))
+        textField.addTarget(self, action: #selector(didChange(_:)), for: .editingChanged)
         textField.clearButtonMode = .whileEditing
     }
     
@@ -41,6 +43,11 @@ class TextFieldContentView: UIView, UIContentView {
     func configure(configuration: UIContentConfiguration) {
         guard let configuration = configuration as? Configuration else { return }
         textField.text = configuration.text
+    }
+    
+    @objc private func didChange(_ sender: UITextField) {
+        guard let configuration = configuration as? TextFieldContentView.Configuration else { return }
+        configuration.onChange(textField.text ?? "")
     }
 }
 

--- a/JustThree/ContentViews/TextViewContentView.swift
+++ b/JustThree/ContentViews/TextViewContentView.swift
@@ -10,6 +10,7 @@ import UIKit
 class TextViewContentView: UIView, UIContentView {
     struct Configuration: UIContentConfiguration {
         var text: String? = ""
+        var onChange: (String)->Void = { _ in }
         
         func makeContentView() -> UIView & UIContentView {
             return TextViewContentView(self)
@@ -32,6 +33,7 @@ class TextViewContentView: UIView, UIContentView {
         super.init(frame: .zero)
         addPinnedSubview(textView, height: 200)
         textView.backgroundColor = nil
+        textView.delegate = self
         textView.font = UIFont.preferredFont(forTextStyle: .body)
     }
     
@@ -48,5 +50,12 @@ class TextViewContentView: UIView, UIContentView {
 extension UICollectionViewListCell {
     func textViewConfiguration() -> TextViewContentView.Configuration {
         TextViewContentView.Configuration()
+    }
+}
+
+extension TextViewContentView: UITextViewDelegate {
+    func textViewDidChange(_ textView: UITextView) {
+        guard let configuration = configuration as? TextViewContentView.Configuration else { return }
+        configuration.onChange(textView.text)
     }
 }

--- a/JustThree/ViewController/MainTabBarViewController.swift
+++ b/JustThree/ViewController/MainTabBarViewController.swift
@@ -15,8 +15,8 @@ class MainTabBarViewController: UITabBarController {
         super.viewDidLoad()
         // Do any additional setup after loading the view.
         
-//        view.backgroundColor = .clear
-        view.backgroundColor = .justThreeNavigationBackground
+        view.backgroundColor = .clear
+//        view.backgroundColor = .justThreeGradientFutureBegin
         
         let listLayout = listLayout()
         

--- a/JustThree/ViewController/ReminderListVIewController/ReminderListViewController+DataSource.swift
+++ b/JustThree/ViewController/ReminderListVIewController/ReminderListViewController+DataSource.swift
@@ -28,7 +28,7 @@ extension ReminderListViewController {
             
             var backgroundConfig = UIBackgroundConfiguration.listGroupedCell()
             backgroundConfig.backgroundColor = .justThreeListCellBackground
-            backgroundConfig.cornerRadius = 8
+//            backgroundConfig.cornerRadius = 8
             cell.backgroundConfiguration = backgroundConfig
         }
     }

--- a/JustThree/ViewController/ReminderListVIewController/ReminderListViewController.swift
+++ b/JustThree/ViewController/ReminderListVIewController/ReminderListViewController.swift
@@ -33,7 +33,10 @@ class ReminderListViewController: UICollectionViewController {
     
     func showDetail(for id: Reminder.ID) {
         let reminder = reminder(for: id)
-        let viewController = ReminderViewController(reminder: reminder)
+        let viewController = ReminderViewController(reminder: reminder) { [weak self] reminder in
+            self?.update(reminder, with: reminder.id)
+            self?.updateSnapshot(reloading: [reminder.id])
+        }
         navigationController?.pushViewController(viewController, animated: true)
     }
 

--- a/JustThree/ViewController/ReminderViewController/ReminderViewController+CellConfiguration.swift
+++ b/JustThree/ViewController/ReminderViewController/ReminderViewController+CellConfiguration.swift
@@ -26,6 +26,9 @@ extension ReminderViewController {
     func titleConfiguration(for cell: UICollectionViewListCell, with title: String?) -> TextFieldContentView.Configuration {
         var contentConfig = cell.textFieldConfiguration()
         contentConfig.text = title
+        contentConfig.onChange = { [weak self] title in
+            self?.workingReminder.title = title
+        }
         return contentConfig
     }
     

--- a/JustThree/ViewController/ReminderViewController/ReminderViewController+CellConfiguration.swift
+++ b/JustThree/ViewController/ReminderViewController/ReminderViewController+CellConfiguration.swift
@@ -35,6 +35,9 @@ extension ReminderViewController {
     func dateConfiguration(for cell: UICollectionViewListCell, with date: Date) -> DatePickerContentView.Configuration {
         var contentConfig = cell.datePickerConfiguration()
         contentConfig.date = date
+        contentConfig.onChange = { [weak self] dueDate in
+            self?.workingReminder.dueDate = dueDate
+        }
         return contentConfig
     }
     

--- a/JustThree/ViewController/ReminderViewController/ReminderViewController+CellConfiguration.swift
+++ b/JustThree/ViewController/ReminderViewController/ReminderViewController+CellConfiguration.swift
@@ -44,6 +44,9 @@ extension ReminderViewController {
     func notesConfiguration(for cell: UICollectionViewListCell, with notes: String?) -> TextViewContentView.Configuration {
         var contentConfig = cell.textViewConfiguration()
         contentConfig.text = notes
+        contentConfig.onChange = { [weak self] notes in
+            self?.workingReminder.notes = notes
+        }
         return contentConfig
     }
     

--- a/JustThree/ViewController/ReminderViewController/ReminderViewController.swift
+++ b/JustThree/ViewController/ReminderViewController/ReminderViewController.swift
@@ -13,12 +13,13 @@ class ReminderViewController: UICollectionViewController {
     private typealias DataSource = UICollectionViewDiffableDataSource<Section, Row>
     private typealias Snapshot = NSDiffableDataSourceSnapshot<Section, Row>
 
-    
     var reminder: Reminder
+    var workingReminder: Reminder
     private lazy var dataSource: DataSource = makeDataSource()
     
     init(reminder: Reminder) {
         self.reminder = reminder
+        self.workingReminder = reminder
         var listConfiguration = UICollectionLayoutListConfiguration(appearance: .insetGrouped)
         listConfiguration.showsSeparators = false
         listConfiguration.headerMode = .firstItemInSection
@@ -42,10 +43,10 @@ class ReminderViewController: UICollectionViewController {
     override func setEditing(_ editing: Bool, animated: Bool) {
         super.setEditing(editing, animated: animated)
         if editing {
-            updateSnapshotForEditing()
+            prepareForEditing()
         }
         else {
-            updateSnapshotForViewing()
+            prepareForViewing()
         }
     }
     
@@ -78,6 +79,10 @@ class ReminderViewController: UICollectionViewController {
         }
     }
     
+    private func prepareForEditing() {
+        updateSnapshotForEditing()
+    }
+    
     private func updateSnapshotForEditing() {
         var snapshot = Snapshot()
         snapshot.appendSections([.title, .date, .notes])
@@ -85,6 +90,13 @@ class ReminderViewController: UICollectionViewController {
         snapshot.appendItems([.header(Section.date.name), .editDate(reminder.dueDate)], toSection: .date)
         snapshot.appendItems([.header(Section.notes.name), .editText(reminder.notes)], toSection: .notes)
         dataSource.apply(snapshot)
+    }
+    
+    private func prepareForViewing() {
+        if workingReminder != reminder {
+            reminder = workingReminder
+        }
+        updateSnapshotForViewing()
     }
     
     private func updateSnapshotForViewing() {

--- a/JustThree/ViewController/ReminderViewController/ReminderViewController.swift
+++ b/JustThree/ViewController/ReminderViewController/ReminderViewController.swift
@@ -37,7 +37,13 @@ class ReminderViewController: UICollectionViewController {
         navigationItem.title = NSLocalizedString("Reminder", comment: "Reminder view controller title")
         navigationItem.rightBarButtonItem = editButtonItem
         
+        tabBarController?.tabBar.isHidden.toggle()
+        
         updateSnapshotForViewing()
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        tabBarController?.tabBar.isHidden.toggle()
     }
     
     override func setEditing(_ editing: Bool, animated: Bool) {

--- a/JustThree/ViewController/ReminderViewController/ReminderViewController.swift
+++ b/JustThree/ViewController/ReminderViewController/ReminderViewController.swift
@@ -85,7 +85,13 @@ class ReminderViewController: UICollectionViewController {
         }
     }
     
+    @objc func didCancelEdit() {
+        workingReminder = reminder
+        setEditing(false, animated: true)
+    }
+    
     private func prepareForEditing() {
+        navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(didCancelEdit))
         updateSnapshotForEditing()
     }
     
@@ -99,6 +105,7 @@ class ReminderViewController: UICollectionViewController {
     }
     
     private func prepareForViewing() {
+        navigationItem.leftBarButtonItem = nil
         if workingReminder != reminder {
             reminder = workingReminder
         }

--- a/JustThree/ViewController/ReminderViewController/ReminderViewController.swift
+++ b/JustThree/ViewController/ReminderViewController/ReminderViewController.swift
@@ -13,13 +13,19 @@ class ReminderViewController: UICollectionViewController {
     private typealias DataSource = UICollectionViewDiffableDataSource<Section, Row>
     private typealias Snapshot = NSDiffableDataSourceSnapshot<Section, Row>
 
-    var reminder: Reminder
+    var reminder: Reminder {
+        didSet {
+            onChange(reminder)
+        }
+    }
     var workingReminder: Reminder
+    var onChange: (Reminder)->Void
     private lazy var dataSource: DataSource = makeDataSource()
     
-    init(reminder: Reminder) {
+    init(reminder: Reminder, onChange: @escaping (Reminder)->Void) {
         self.reminder = reminder
         self.workingReminder = reminder
+        self.onChange = onChange
         var listConfiguration = UICollectionLayoutListConfiguration(appearance: .insetGrouped)
         listConfiguration.showsSeparators = false
         listConfiguration.headerMode = .firstItemInSection


### PR DESCRIPTION
Add an editing mode to the app that lets users edit the details of a reminder.

When the user taps the Done button, the app saves the reminder edits, returns to view mode, and updates all relevant views. Or if the user taps the Cancel button, the app discards the changes and returns to view mode.