### PR TITLE
Feature/filtering reminders

### DIFF
--- a/JustThree.xcodeproj/project.pbxproj
+++ b/JustThree.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		BD0CADAE28E380AC007D2EF7 /* TextViewContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD0CADAD28E380AC007D2EF7 /* TextViewContentView.swift */; };
 		BD0CADB028E38591007D2EF7 /* DatePickerContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD0CADAF28E38591007D2EF7 /* DatePickerContentView.swift */; };
 		BD559CB628DF624500625B82 /* Date+TextFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD559CB528DF624500625B82 /* Date+TextFormat.swift */; };
+		BD8DBE3528E4EBCD00718F85 /* ReminderViewController+DataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD8DBE3428E4EBCC00718F85 /* ReminderViewController+DataSource.swift */; };
 		BD9EC94E28DE478300B803D7 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD9EC94D28DE478300B803D7 /* AppDelegate.swift */; };
 		BD9EC95028DE478300B803D7 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD9EC94F28DE478300B803D7 /* SceneDelegate.swift */; };
 		BD9EC95228DE478300B803D7 /* MainTabBarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD9EC95128DE478300B803D7 /* MainTabBarViewController.swift */; };
@@ -46,6 +47,7 @@
 		BD0CADAD28E380AC007D2EF7 /* TextViewContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextViewContentView.swift; sourceTree = "<group>"; };
 		BD0CADAF28E38591007D2EF7 /* DatePickerContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatePickerContentView.swift; sourceTree = "<group>"; };
 		BD559CB528DF624500625B82 /* Date+TextFormat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+TextFormat.swift"; sourceTree = "<group>"; };
+		BD8DBE3428E4EBCC00718F85 /* ReminderViewController+DataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReminderViewController+DataSource.swift"; sourceTree = "<group>"; };
 		BD9EC94A28DE478300B803D7 /* JustThree.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = JustThree.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BD9EC94D28DE478300B803D7 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		BD9EC94F28DE478300B803D7 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -96,6 +98,7 @@
 			isa = PBXGroup;
 			children = (
 				BD0CAD9C28E1E2A2007D2EF7 /* ReminderViewController.swift */,
+				BD8DBE3428E4EBCC00718F85 /* ReminderViewController+DataSource.swift */,
 				BD0CAD9E28E1E3C6007D2EF7 /* ReminderViewController+Row.swift */,
 				BD0CADA028E231D6007D2EF7 /* ReminderViewController+Section.swift */,
 				BD0CADA228E23BD7007D2EF7 /* ReminderViewController+CellConfiguration.swift */,
@@ -230,6 +233,7 @@
 				BD0CADA128E231D6007D2EF7 /* ReminderViewController+Section.swift in Sources */,
 				BD0CAD9228E1CF81007D2EF7 /* UIColor+JustThree.swift in Sources */,
 				BD559CB628DF624500625B82 /* Date+TextFormat.swift in Sources */,
+				BD8DBE3528E4EBCD00718F85 /* ReminderViewController+DataSource.swift in Sources */,
 				BD0CAD9428E1D0FC007D2EF7 /* ReminderListViewController+DataSource.swift in Sources */,
 				BD9EC96528DE55AD00B803D7 /* SettingListViewController.swift in Sources */,
 				BD0CADAC28E240A2007D2EF7 /* UIContentConfiguration+Stateless.swift in Sources */,

--- a/JustThree.xcodeproj/project.pbxproj
+++ b/JustThree.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		BD0CADB028E38591007D2EF7 /* DatePickerContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD0CADAF28E38591007D2EF7 /* DatePickerContentView.swift */; };
 		BD559CB628DF624500625B82 /* Date+TextFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD559CB528DF624500625B82 /* Date+TextFormat.swift */; };
 		BD8DBE3528E4EBCD00718F85 /* ReminderViewController+DataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD8DBE3428E4EBCC00718F85 /* ReminderViewController+DataSource.swift */; };
+		BD8DBE3728E5E6C400718F85 /* ReminderListStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD8DBE3628E5E6C400718F85 /* ReminderListStyle.swift */; };
 		BD9EC94E28DE478300B803D7 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD9EC94D28DE478300B803D7 /* AppDelegate.swift */; };
 		BD9EC95028DE478300B803D7 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD9EC94F28DE478300B803D7 /* SceneDelegate.swift */; };
 		BD9EC95228DE478300B803D7 /* MainTabBarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD9EC95128DE478300B803D7 /* MainTabBarViewController.swift */; };
@@ -48,6 +49,7 @@
 		BD0CADAF28E38591007D2EF7 /* DatePickerContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatePickerContentView.swift; sourceTree = "<group>"; };
 		BD559CB528DF624500625B82 /* Date+TextFormat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+TextFormat.swift"; sourceTree = "<group>"; };
 		BD8DBE3428E4EBCC00718F85 /* ReminderViewController+DataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReminderViewController+DataSource.swift"; sourceTree = "<group>"; };
+		BD8DBE3628E5E6C400718F85 /* ReminderListStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReminderListStyle.swift; sourceTree = "<group>"; };
 		BD9EC94A28DE478300B803D7 /* JustThree.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = JustThree.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BD9EC94D28DE478300B803D7 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		BD9EC94F28DE478300B803D7 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -156,6 +158,7 @@
 				BD9EC96728DF520400B803D7 /* Reminder.swift */,
 				BD559CB528DF624500625B82 /* Date+TextFormat.swift */,
 				BD0CAD9128E1CF81007D2EF7 /* UIColor+JustThree.swift */,
+				BD8DBE3628E5E6C400718F85 /* ReminderListStyle.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -241,6 +244,7 @@
 				BD9EC96328DE553B00B803D7 /* ReminderListViewController.swift in Sources */,
 				BD9EC95228DE478300B803D7 /* MainTabBarViewController.swift in Sources */,
 				BD0CADAE28E380AC007D2EF7 /* TextViewContentView.swift in Sources */,
+				BD8DBE3728E5E6C400718F85 /* ReminderListStyle.swift in Sources */,
 				BD9EC96828DF520400B803D7 /* Reminder.swift in Sources */,
 				BD0CAD9728E1DA65007D2EF7 /* ReminderDoneButton.swift in Sources */,
 				BD0CADAA28E23FE1007D2EF7 /* TextFieldContentView.swift in Sources */,

--- a/JustThree/Models/ReminderListStyle.swift
+++ b/JustThree/Models/ReminderListStyle.swift
@@ -12,6 +12,17 @@ enum ReminderListStyle: Int {
     case future
     case all
     
+    var name: String {
+        switch self {
+        case .today:
+            return NSLocalizedString("Today", comment: "Today style name")
+        case .future:
+            return NSLocalizedString("Future", comment: "Future style name")
+        case .all:
+            return NSLocalizedString("All", comment: "All style name")
+        }
+    }
+    
     func shouldInclude(date: Date) -> Bool {
         let isInToday = Locale.current.calendar.isDateInToday(date)
         switch self {

--- a/JustThree/Models/ReminderListStyle.swift
+++ b/JustThree/Models/ReminderListStyle.swift
@@ -1,0 +1,26 @@
+//
+//  ReminderListStyle.swift
+//  JustThree
+//
+//  Created by Sanghun Park on 29.09.22.
+//
+
+import Foundation
+
+enum ReminderListStyle: Int {
+    case today
+    case future
+    case all
+    
+    func shouldInclude(date: Date) -> Bool {
+        let isInToday = Locale.current.calendar.isDateInToday(date)
+        switch self {
+        case .today:
+            return isInToday
+        case .future:
+            return (date > Date.now) && !isInToday
+        case .all:
+            return true
+        }
+    }
+}

--- a/JustThree/ViewController/ReminderListVIewController/ReminderListViewController+Actions.swift
+++ b/JustThree/ViewController/ReminderListVIewController/ReminderListViewController+Actions.swift
@@ -32,4 +32,9 @@ extension ReminderListViewController {
     @objc func didCancelAdd(_ sender: UIBarButtonItem) {
         dismiss(animated: true)
     }
+    
+    @objc func didChangeListStyle(_ sender: UISegmentedControl) {
+        listStyle = ReminderListStyle(rawValue: sender.selectedSegmentIndex) ?? .today
+        updateSnapshot()
+    }
 }

--- a/JustThree/ViewController/ReminderListVIewController/ReminderListViewController+DataSource.swift
+++ b/JustThree/ViewController/ReminderListVIewController/ReminderListViewController+DataSource.swift
@@ -49,10 +49,11 @@ extension ReminderListViewController {
         }
     }
     
-    func updateSnapshot(reloading ids: [Reminder.ID] = []) {
+    func updateSnapshot(reloading idsChanged: [Reminder.ID] = []) {
+        let ids = idsChanged.filter { id in filteredReminders.contains(where: { $0.id == id }) }
         var snapshot = Snapshot()
         snapshot.appendSections([0])
-        snapshot.appendItems(reminders.map { $0.id })
+        snapshot.appendItems(filteredReminders.map { $0.id })
         if !ids.isEmpty {
             snapshot.reloadItems(ids)
         }

--- a/JustThree/ViewController/ReminderListVIewController/ReminderListViewController.swift
+++ b/JustThree/ViewController/ReminderListVIewController/ReminderListViewController.swift
@@ -7,8 +7,6 @@
 
 import UIKit
 
-//private let reuseIdentifier = "Cell"
-
 class ReminderListViewController: UICollectionViewController {
     
     var reminders: [Reminder] = Reminder.sampleData
@@ -18,13 +16,6 @@ class ReminderListViewController: UICollectionViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        // Uncomment the following line to preserve selection between presentations
-        //self.clearsSelectionOnViewWillAppear = false
-
-        // Register cell classes
-        //self.collectionView!.register(UICollectionViewCell.self, forCellWithReuseIdentifier: reuseIdentifier)
-
-        // Do any additional setup after loading the view.
         let listLayout = listLayout()
         collectionView.collectionViewLayout = listLayout
         
@@ -56,7 +47,7 @@ class ReminderListViewController: UICollectionViewController {
         return UICollectionViewCompositionalLayout.list(using: listConfiguration)
     }
     
-    func makeSwipeActions(for indexPath: IndexPath?) -> UISwipeActionsConfiguration? {
+    private func makeSwipeActions(for indexPath: IndexPath?) -> UISwipeActionsConfiguration? {
         guard let indexPath = indexPath, let id = dataSource.itemIdentifier(for: indexPath) else { return nil }
         let deleteActionTitle = NSLocalizedString("Delete", comment: "Delete action title")
         let deleteAction = UIContextualAction(style: .destructive, title: deleteActionTitle) { [weak self] _, _, completion in
@@ -70,39 +61,7 @@ class ReminderListViewController: UICollectionViewController {
 }
 
 extension ReminderListViewController {
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using [segue destinationViewController].
-        // Pass the selected object to the new view controller.
-    }
-    */
-
-    /*
-    // MARK: UICollectionViewDataSource
-
-    override func numberOfSections(in collectionView: UICollectionView) -> Int {
-        // #warning Incomplete implementation, return the number of sections
-        return 0
-    }
-
-
-    override func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        // #warning Incomplete implementation, return the number of items
-        return 0
-    }
-
-    override func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: reuseIdentifier, for: indexPath)
     
-        // Configure the cell
-    
-        return cell
-    }
-    */
-
     // MARK: UICollectionViewDelegate
 
     /*

--- a/JustThree/ViewController/ReminderListVIewController/ReminderListViewController.swift
+++ b/JustThree/ViewController/ReminderListVIewController/ReminderListViewController.swift
@@ -9,9 +9,13 @@ import UIKit
 
 class ReminderListViewController: UICollectionViewController {
     
+    lazy var dataSource: DataSource = makeDataSource()
     var reminders: [Reminder] = Reminder.sampleData
     
-    lazy var dataSource: DataSource = makeDataSource()
+    var filteredReminders: [Reminder] {
+        return reminders.filter { listStyle.shouldInclude(date: $0.dueDate) }.sorted { $0.dueDate < $1.dueDate }
+    }
+    var listStyle: ReminderListStyle = .today
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -73,7 +77,7 @@ extension ReminderListViewController {
 
     // Uncomment this method to specify if the specified item should be selected
     override func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {
-        let id = reminders[indexPath.item].id
+        let id = filteredReminders[indexPath.item].id
         showDetail(for: id)
         return false
     }

--- a/JustThree/ViewController/ReminderListVIewController/ReminderListViewController.swift
+++ b/JustThree/ViewController/ReminderListVIewController/ReminderListViewController.swift
@@ -16,6 +16,9 @@ class ReminderListViewController: UICollectionViewController {
         return reminders.filter { listStyle.shouldInclude(date: $0.dueDate) }.sorted { $0.dueDate < $1.dueDate }
     }
     var listStyle: ReminderListStyle = .today
+    let listStyleSegmentedControl = UISegmentedControl(items: [
+        ReminderListStyle.today.name, ReminderListStyle.future.name, ReminderListStyle.all.name
+    ])
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -26,6 +29,9 @@ class ReminderListViewController: UICollectionViewController {
         let addButton = UIBarButtonItem(barButtonSystemItem: .add, target: self, action: #selector(didPressAddButton(_:)))
         addButton.accessibilityLabel = NSLocalizedString("Add reminder", comment: "Add button accessibility label")
         navigationItem.rightBarButtonItem = addButton
+        
+        listStyleSegmentedControl.selectedSegmentIndex = listStyle.rawValue
+        navigationItem.titleView = listStyleSegmentedControl
         
         updateSnapshot()
         

--- a/JustThree/ViewController/ReminderListVIewController/ReminderListViewController.swift
+++ b/JustThree/ViewController/ReminderListVIewController/ReminderListViewController.swift
@@ -31,6 +31,7 @@ class ReminderListViewController: UICollectionViewController {
         navigationItem.rightBarButtonItem = addButton
         
         listStyleSegmentedControl.selectedSegmentIndex = listStyle.rawValue
+        listStyleSegmentedControl.addTarget(self, action: #selector(didChangeListStyle(_:)), for: .valueChanged)
         navigationItem.titleView = listStyleSegmentedControl
         
         updateSnapshot()

--- a/JustThree/ViewController/ReminderViewController/ReminderViewController+DataSource.swift
+++ b/JustThree/ViewController/ReminderViewController/ReminderViewController+DataSource.swift
@@ -1,0 +1,68 @@
+//
+//  ReminderViewController+DataSource.swift
+//  JustThree
+//
+//  Created by Sanghun Park on 28.09.22.
+//
+
+import UIKit
+
+extension ReminderViewController {
+    typealias DataSource = UICollectionViewDiffableDataSource<Section, Row>
+    typealias Snapshot = NSDiffableDataSourceSnapshot<Section, Row>
+    
+    private func cellRegistration() -> UICollectionView.CellRegistration<UICollectionViewListCell, Row> {
+        return .init { (cell: UICollectionViewListCell, indexPath: IndexPath, row: Row) in
+            
+            let section = self.section(for: indexPath)
+            switch (section, row) {
+            case (_, .header(let title)):
+                cell.contentConfiguration = self.headerConfiguration(for: cell, with: title)
+            case (.view, _):
+                cell.contentConfiguration = self.defaultConfiguration(for: cell, at: row)
+            case (.title, .editText(let title)):
+                cell.contentConfiguration = self.titleConfiguration(for: cell, with: title)
+            case (.date, .editDate(let date)):
+                cell.contentConfiguration = self.dateConfiguration(for: cell, with: date)
+            case (.notes, .editText(let notes)):
+                cell.contentConfiguration = self.notesConfiguration(for: cell, with: notes)
+            default:
+                fatalError("Unexpected combination of section and row.")
+            }
+            cell.tintColor = .justThreePrimaryTint
+        }
+    }
+    
+    func makeDataSource() -> DataSource {
+        let cellRegistration = cellRegistration()
+        return DataSource(collectionView: collectionView) { (collectionView: UICollectionView, indexPath: IndexPath, itemIdentifier: Row) in
+            return collectionView.dequeueConfiguredReusableCell(using: cellRegistration, for: indexPath, item: itemIdentifier)
+        }
+    }
+    
+    func updateSnapshotForEditing() {
+        var snapshot = Snapshot()
+        snapshot.appendSections([.title, .date, .notes])
+        snapshot.appendItems([.header(Section.title.name), .editText(reminder.title)], toSection: .title)
+        snapshot.appendItems([.header(Section.date.name), .editDate(reminder.dueDate)], toSection: .date)
+        snapshot.appendItems([.header(Section.notes.name), .editText(reminder.notes)], toSection: .notes)
+        dataSource.apply(snapshot)
+    }
+    
+    
+    func updateSnapshotForViewing() {
+        var snapshot = Snapshot()
+        snapshot.appendSections([.view])
+        snapshot.appendItems([.header(""), .viewTitle, .viewDate, .viewTime, .viewNotes], toSection: .view)
+        dataSource.apply(snapshot)
+    }
+    
+    private func section(for indexPath: IndexPath) -> Section {
+        let sectionNumber = isEditing ? indexPath.section + 1 : indexPath.section
+        guard let section = Section(rawValue: sectionNumber) else {
+            fatalError("Unable to find matching section")
+        }
+        return section
+    }
+    
+}

--- a/JustThree/ViewController/ReminderViewController/ReminderViewController.swift
+++ b/JustThree/ViewController/ReminderViewController/ReminderViewController.swift
@@ -7,11 +7,7 @@
 
 import UIKit
 
-//private let reuseIdentifier = "Cell"
-
 class ReminderViewController: UICollectionViewController {
-    private typealias DataSource = UICollectionViewDiffableDataSource<Section, Row>
-    private typealias Snapshot = NSDiffableDataSourceSnapshot<Section, Row>
 
     var reminder: Reminder {
         didSet {
@@ -21,7 +17,7 @@ class ReminderViewController: UICollectionViewController {
     var workingReminder: Reminder
     var isAddingNewReminder = false
     var onChange: (Reminder)->Void
-    private lazy var dataSource: DataSource = makeDataSource()
+    lazy var dataSource: DataSource = makeDataSource()
     
     init(reminder: Reminder, onChange: @escaping (Reminder)->Void) {
         self.reminder = reminder
@@ -68,35 +64,6 @@ class ReminderViewController: UICollectionViewController {
         }
     }
     
-    func cellRegistration() -> UICollectionView.CellRegistration<UICollectionViewListCell, Row> {
-        return .init { (cell: UICollectionViewListCell, indexPath: IndexPath, row: Row) in
-            
-            let section = self.section(for: indexPath)
-            switch (section, row) {
-            case (_, .header(let title)):
-                cell.contentConfiguration = self.headerConfiguration(for: cell, with: title)
-            case (.view, _):
-                cell.contentConfiguration = self.defaultConfiguration(for: cell, at: row)
-            case (.title, .editText(let title)):
-                cell.contentConfiguration = self.titleConfiguration(for: cell, with: title)
-            case (.date, .editDate(let date)):
-                cell.contentConfiguration = self.dateConfiguration(for: cell, with: date)
-            case (.notes, .editText(let notes)):
-                cell.contentConfiguration = self.notesConfiguration(for: cell, with: notes)
-            default:
-                fatalError("Unexpected combination of section and row.")
-            }
-            cell.tintColor = .justThreePrimaryTint
-        }
-    }
-    
-    private func makeDataSource() -> DataSource {
-        let cellRegistration = cellRegistration()
-        return DataSource(collectionView: collectionView) { (collectionView: UICollectionView, indexPath: IndexPath, itemIdentifier: Row) in
-            return collectionView.dequeueConfiguredReusableCell(using: cellRegistration, for: indexPath, item: itemIdentifier)
-        }
-    }
-    
     @objc func didCancelEdit() {
         workingReminder = reminder
         setEditing(false, animated: true)
@@ -107,36 +74,12 @@ class ReminderViewController: UICollectionViewController {
         updateSnapshotForEditing()
     }
     
-    private func updateSnapshotForEditing() {
-        var snapshot = Snapshot()
-        snapshot.appendSections([.title, .date, .notes])
-        snapshot.appendItems([.header(Section.title.name), .editText(reminder.title)], toSection: .title)
-        snapshot.appendItems([.header(Section.date.name), .editDate(reminder.dueDate)], toSection: .date)
-        snapshot.appendItems([.header(Section.notes.name), .editText(reminder.notes)], toSection: .notes)
-        dataSource.apply(snapshot)
-    }
-    
     private func prepareForViewing() {
         navigationItem.leftBarButtonItem = nil
         if workingReminder != reminder {
             reminder = workingReminder
         }
         updateSnapshotForViewing()
-    }
-    
-    private func updateSnapshotForViewing() {
-        var snapshot = Snapshot()
-        snapshot.appendSections([.view])
-        snapshot.appendItems([.header(""), .viewTitle, .viewDate, .viewTime, .viewNotes], toSection: .view)
-        dataSource.apply(snapshot)
-    }
-    
-    private func section(for indexPath: IndexPath) -> Section {
-        let sectionNumber = isEditing ? indexPath.section + 1 : indexPath.section
-        guard let section = Section(rawValue: sectionNumber) else {
-            fatalError("Unable to find matching section")
-        }
-        return section
     }
     
 }


### PR DESCRIPTION
For users to more easily access their reminders on the app’s main view, create a ListStyle enumeration that separates reminders into three categories: Today, Future, and All. Also add a segmented control that lets users select different styles for the reminders list.