### PR TITLE
feat: Saving and loading reminder data in the UserDefaults

### DIFF
--- a/JustThree/Models/Reminder.swift
+++ b/JustThree/Models/Reminder.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct Reminder: Equatable, Identifiable {
+struct Reminder: Equatable, Identifiable, Codable {
     var id: String = UUID().uuidString
     var title: String
     var dueDate: Date
@@ -21,6 +21,29 @@ extension Array where Element == Reminder {
             fatalError()
         }
         return index
+    }
+}
+
+class Reminders {
+    static let shared: Reminders = Reminders()
+    let saveKey = "com.sanghun.JustThree.SavedData"
+    
+    var reminders: [Reminder]
+    
+    init() {
+        if let data = UserDefaults.standard.data(forKey: saveKey) {
+            if let decoded = try? JSONDecoder().decode([Reminder].self, from: data) {
+                reminders = decoded
+                return
+            }
+        }
+        reminders = []
+    }
+    
+    func save() {
+        if let encoded = try? JSONEncoder().encode(reminders) {
+            UserDefaults.standard.set(encoded, forKey: saveKey)
+        }
     }
 }
 

--- a/JustThree/ViewController/ReminderListVIewController/ReminderListViewController.swift
+++ b/JustThree/ViewController/ReminderListVIewController/ReminderListViewController.swift
@@ -10,7 +10,12 @@ import UIKit
 class ReminderListViewController: UICollectionViewController {
     
     lazy var dataSource: DataSource = makeDataSource()
-    var reminders: [Reminder] = []
+    var reminders: [Reminder] = [] {
+        didSet {
+            Reminders.shared.reminders = reminders
+            Reminders.shared.save()
+        }
+    }
     
     var filteredReminders: [Reminder] {
         let filtered = reminders.filter { listStyle.shouldInclude(date: $0.dueDate) }.sorted { $0.dueDate < $1.dueDate }
@@ -39,6 +44,8 @@ class ReminderListViewController: UICollectionViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        reminders = Reminders.shared.reminders
         
         collectionView.backgroundColor = .secondarySystemBackground
 


### PR DESCRIPTION
Reminder.swift
- Modify the Reminder to conform Codable protocol to encode and decode when using with UserDefaults.
- Add new class with singleton to save and load the array of reminders data using the UserDefaults.

ReminderListViewController.swift
- In `viewDidLoad()`, make `reminders` initiate with loaded data from UserDefaults.
- Add `didSet` to `reminders` to update and save the reminders when there are changes.